### PR TITLE
Move the includes out of the namespace

### DIFF
--- a/.github/workflows/udmp-parser.yml
+++ b/.github/workflows/udmp-parser.yml
@@ -2,11 +2,6 @@ name: Builds
 
 on: [push, pull_request]
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-
 jobs:
   Windows:
     runs-on: windows-latest 
@@ -23,7 +18,7 @@ jobs:
     name: Windows latest / ${{ matrix.generator }}.${{ matrix.arch }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1
@@ -45,7 +40,7 @@ jobs:
 
     - name: Upload artifacts
       if: matrix.generator == 'ninja'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: bin-${{ matrix.arch }}.RelWithDebInfo
         path: |
@@ -62,19 +57,19 @@ jobs:
     name: Ubuntu 20.04 / ${{ matrix.compiler }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Installing dependencies
       run: |
         sudo apt-get -y update
-        sudo apt install -y g++-10 ninja-build
+        sudo apt install -y g++-12 ninja-build
         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
     - name: Build with gcc
       if: matrix.compiler == 'gcc'
       env:
-        CC: gcc-10
-        CXX: g++-10
+        CC: gcc-12
+        CXX: g++-12
       run: |
         cd src/build
         chmod u+x ./build-release.sh
@@ -83,15 +78,15 @@ jobs:
     - name: Build with clang
       if: matrix.compiler == 'clang'
       env:
-        CC: clang-13
-        CXX: clang++-13
+        CC: clang-15
+        CXX: clang++-15
       run: |
         cd src/build
         chmod u+x ./build-release.sh
         ./build-release.sh
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: bin-lin64-${{ matrix.compiler }}.Release
         path: |
@@ -105,7 +100,7 @@ jobs:
     name: OSX Latest / clang
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build with clang
       env:
@@ -117,7 +112,7 @@ jobs:
         ./build-release-osx.sh
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: bin-osxx64-clang.Release
         path: |

--- a/.github/workflows/udmp-parser.yml
+++ b/.github/workflows/udmp-parser.yml
@@ -48,13 +48,13 @@ jobs:
           src/build/parser/parser.pdb
 
   Linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         compiler: ['clang', 'gcc']
 
-    name: Ubuntu 20.04 / ${{ matrix.compiler }}
+    name: Ubuntu Latest / ${{ matrix.compiler }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/src/lib/udmp-parser.h
+++ b/src/lib/udmp-parser.h
@@ -31,6 +31,12 @@
 #elif defined(linux) || defined(__linux) || defined(__FreeBSD__) ||            \
     defined(__FreeBSD_kernel__) || defined(__MACH__)
 #define LINUX
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #define EXIT_FAILURE 1
 #define EXIT_SUCCESS 0
@@ -575,13 +581,6 @@ public:
 };
 
 #elif defined(LINUX)
-
-#include <errno.h>
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 class FileMap_t {
   void *ViewBase_ = nullptr;


### PR DESCRIPTION
This causes `unistd`'s functions, etc. to be in the `udmpparser` namespace which causes issues on OSX in one other project I am working on:
```
utils.cc:597:26: error: use of undeclared identifier 'readlink'; did you mean 'udmpparser::readlink'?
  const ssize_t Length = readlink("/proc/self/exe", ExePathBuffer.data(),
                         ^~~~~~~~
                         udmpparser::readlink
/Applications/Xcode_14.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/unistd.h:627:10: note: 'udmpparser::readlink' declared here
ssize_t  readlink(const char * __restrict, char * __restrict, size_t);
         ^
1 error generated.
```

It also updates / fixes the CI.