### PR TITLE
CMake subdirectory support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ﻿# Axel '0vercl0k' Souchet - January 22 2022
 # Note: the cmake version must be the same as in python/pyproject.toml::tool.scikit-build:cmake.minimum-version
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_POSITION_INDEPENDENT_CODE True)
@@ -15,15 +15,11 @@ project(
 set(PROJECT_AUTHOR 0vercl0k)
 set(PROJECT_LICENSE MIT)
 
-option(BUILD_PARSER "Build the parser executable for UdmpParser" ON)
-option(BUILD_PYTHON_BINDING "Build the Python binding for UdmpParser" ON)
+option(BUILD_PARSER "Build the parser executable for UdmpParser" ${PROJECT_IS_TOP_LEVEL})
+option(UDMP_PARSER_INSTALL "Install targets" ${PROJECT_IS_TOP_LEVEL})
 
 add_subdirectory(lib)
 
 if(BUILD_PARSER)
     add_subdirectory(parser)
 endif(BUILD_PARSER)
-
-if(BUILD_PYTHON_BINDING)
-    add_subdirectory(python)
-endif(BUILD_PYTHON_BINDING)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -2,4 +2,10 @@
 add_library(udmp-parser INTERFACE)
 target_include_directories(udmp-parser INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
-install(FILES $<TARGET_PROPERTY:udmp-parser,INTERFACE_INCLUDE_DIRECTORIES>/udmp-parser.h DESTINATION inc)
+if(WIN32)
+    target_compile_definitions(udmp-parser INTERFACE NOMINMAX)
+endif()
+
+if(UDMP_PARSER_INSTALL)
+    install(FILES $<TARGET_PROPERTY:udmp-parser,INTERFACE_INCLUDE_DIRECTORIES>/udmp-parser.h DESTINATION inc)
+endif(UDMP_PARSER_INSTALL)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -19,8 +19,10 @@ endif()
 
 target_link_libraries(parser PRIVATE udmp-parser)
 
-install(FILES $<TARGET_FILE:parser> DESTINATION bin)
+if(UDMP_PARSER_INSTALL)
+    install(FILES $<TARGET_FILE:parser> DESTINATION bin)
 
-if(MSVC)
-    install(FILES $<TARGET_PDB_FILE:parser> DESTINATION bin OPTIONAL)
-endif(MSVC)
+    if(MSVC)
+        install(FILES $<TARGET_PDB_FILE:parser> DESTINATION bin OPTIONAL)
+    endif(MSVC)
+endif()

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -6,7 +6,7 @@
 # With contribution from:
 # * hugsy - (github.com/hugsy)
 #
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 
 project(
     udmp-parser-python
@@ -14,6 +14,10 @@ project(
     HOMEPAGE_URL https://github.com/0vercl0k/udmp-parser
     VERSION 0.6.0
 )
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+    message(FATAL_ERROR "This project is not intended to be used as a sub-project")
+endif()
 
 find_package(Python 3
     REQUIRED COMPONENTS Interpreter Development.Module
@@ -40,24 +44,12 @@ if(MSVC)
     target_link_libraries(udmp_parser PRIVATE DbgHelp.lib)
 endif(MSVC)
 
-if(BUILD_PYTHON_PACKAGE)
-    #
-    # Those directives are only used when creating a standalone `udmp_parser` python package
-    #
-    target_include_directories(udmp_parser PRIVATE ../lib)
-    install(TARGETS udmp_parser LIBRARY DESTINATION .)
-    install(DIRECTORY udmp_parser-stubs DESTINATION .)
-else()
-    #
-    # This is the general case, when built from the root cmakefile
-    #
-    target_include_directories(udmp_parser PRIVATE $<TARGET_PROPERTY:udmp-parser,INTERFACE_INCLUDE_DIRECTORIES>)
-    install(TARGETS udmp_parser DESTINATION bindings/python)
-
-    if(MSVC)
-        install(FILES $<TARGET_PDB_FILE:udmp_parser> DESTINATION bindings/python OPTIONAL)
-    endif(MSVC)
-endif()
+#
+# Those directives are only used when creating a standalone `udmp_parser` python package
+#
+target_include_directories(udmp_parser PRIVATE ../lib)
+install(TARGETS udmp_parser LIBRARY DESTINATION .)
+install(DIRECTORY udmp_parser-stubs DESTINATION .)
 
 if(WIN32)
     target_compile_definitions(udmp_parser PRIVATE NOMINMAX)

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -36,8 +36,7 @@ profile = "black"
 wheel.py-api = "cp313"
 minimum-version = "0.4"
 build-dir = "build/{wheel_tag}"
-cmake.minimum-version = "3.20"
-cmake.args = ["-DBUILD_PYTHON_PACKAGE:BOOL=ON"]
+cmake.minimum-version = "3.21"
 
 [tool.cibuildwheel]
 build-verbosity = 1


### PR DESCRIPTION
Makes the library friendly to consume via `add_subdirectory`. Changes:
- CMake 3.21 is for `PROJECT_IS_TOP_LEVEL` support, can be reimplemented if really necessary
- Only produce executable targets and install if the project is compiled as the top level project, otherwise just create the `udmp-parser` target that can be consumed
- Support parsing from memory by passing a `MemoryView_t`